### PR TITLE
Toast Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.9.9",
+    "@material-ui/lab": "^4.0.0-alpha.50",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
@@ -22,7 +23,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "start": "node server.js"
+    "start": "node server.js",
+    "react-start": "react-scripts start"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/components/Charts.js
+++ b/src/components/Charts.js
@@ -1,32 +1,40 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { ChartContext } from '../providers/ChartProvider'
 import CityChart from './CityChart'
+import Toast from './Toast'
 import { Button, Paper, Card, CardHeader, Typography } from '@material-ui/core'
 import CountyChart from './CountyChart'
 
 export default function Charts() {
   const {state, dispatch} = useContext(ChartContext)
+  const [openToast, setOpenToast] = useState(false)
 
   const charts = state.map((item, index) => (
     <Card>
       <Typography gutterBottom variant="h5" component="h2">
           Local
-          </Typography>
+      </Typography>
       <CityChart row={index} />
     </Card>
   ))
+
+  const onRememberChartsClick = () => {
+    dispatch({type: 'rememberCharts'})
+    setOpenToast(true)
+  }
 
   return (
     <div style={{backgroundColor: '#f5f5f5'}}>
       {charts}
       <Button onClick={() => dispatch({type: 'addChart'}) } style={{marginRight: '10px'}}>Add local graph</Button>
-      <Button variant='outlined' onClick={() => dispatch({type: 'rememberCharts'})}>Remember local graphs for next time</Button>
+      <Button variant='outlined' onClick={onRememberChartsClick}>Remember local graphs for next time</Button>
       <Card style={{ marginTop: '20px'}}>
         <Typography gutterBottom variant="h5" component="h2">
           Counties of California
         </Typography>
         <CountyChart />
       </Card>
+      <Toast onClose={() => setOpenToast(false)} open={openToast} />
     </div>
   )
 }

--- a/src/components/Charts.js
+++ b/src/components/Charts.js
@@ -34,7 +34,11 @@ export default function Charts() {
         </Typography>
         <CountyChart />
       </Card>
-      <Toast onClose={() => setOpenToast(false)} open={openToast} />
+      <Toast
+        onClose={() => setOpenToast(false)}
+        open={openToast}
+        text='Local graph has been saved saved!'
+      />
     </div>
   )
 }

--- a/src/components/Charts.js
+++ b/src/components/Charts.js
@@ -37,7 +37,7 @@ export default function Charts() {
       <Toast
         onClose={() => setOpenToast(false)}
         open={openToast}
-        text='Local graph has been saved saved!'
+        text='Local graph has been saved!'
       />
     </div>
   )

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Snackbar } from '@material-ui/core'
+import MuiAlert from '@material-ui/lab/Alert'
+
+export default function Toast(props) {
+  const {
+    autoHideDuration = 4500,
+    anchorOrigin = { vertical: 'bottom', horizontal: 'right' },
+    onClose = () => {},
+    open = false,
+    severity = 'success', // Possible severity types: error, warning, info, & success
+  } = props
+
+  function Alert(alertProps) {
+    return <MuiAlert elevation={6} variant="filled" {...alertProps} />
+  }
+
+  return (
+    <Snackbar
+      autoHideDuration={autoHideDuration}
+      anchorOrigin={anchorOrigin}
+      onClose={onClose}
+      open={open}
+    >
+      <Alert severity={severity}>
+          Local graph is saved!
+      </Alert>
+    </Snackbar>
+  )
+}

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Snackbar } from '@material-ui/core'
+import Snackbar from '@material-ui/core/Snackbar'
 import MuiAlert from '@material-ui/lab/Alert'
 
 export default function Toast(props) {

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -9,6 +9,7 @@ export default function Toast(props) {
     onClose = () => {},
     open = false,
     severity = 'success', // Possible severity types: error, warning, info, & success
+    text = 'Success!',
   } = props
 
   function Alert(alertProps) {
@@ -23,7 +24,7 @@ export default function Toast(props) {
       open={open}
     >
       <Alert severity={severity}>
-          Local graph is saved!
+        {text}
       </Alert>
     </Snackbar>
   )


### PR DESCRIPTION
Created a toast component which can be re-used for future use-cases. Also, after a user click's: "Remember local graphs for next time," a success toast is displayed to the user informing them that their local graph has been saved. The Snackbar component, the toast component for material UI, produces a warning message when triggered for the first time. Something about needing to create a forward ref, but I didnt spend too much time getting to the bottom of it because I wanted to create this pull request before the week started. Here is an image of the warning it produces: https://share.getcloudapp.com/X6uONg2D.  

I installed material UI lab to easily and quickly style the toast component. I also added a new script in order to test my changes because I dont have access to the `build` directory (which is required for the `npm start` command you created).

It's really special for me to think that 3 years ago, you were teaching me to code and that now I might be able to help you on a side project (if you approve my PR that is). If you have any feedback for me (positive or negative), I would love to hear it as well! Hope all is going well in your life and in your family's life!